### PR TITLE
Add option for adding forwarded ports

### DIFF
--- a/bin/runtime-qemu.js
+++ b/bin/runtime-qemu.js
@@ -33,7 +33,7 @@ if (printNetdump) {
 
 var command = argv._[0];
 if (!command) {
-  shell.echo('usage: runtime-qemu [--net[=<type>]] [--netdump] [--kvm] [--curses]');
+  shell.echo('usage: runtime-qemu [--net[=<type>]] [--netdump] [--kvm] [--curses] [--port=<portnum>]...');
   shell.echo('                    [--append=<value>] [--dry-run] [--verbose] [--virtio-rng]');
   shell.echo('                    [--kernel=<kernel>] [--kernelver=<ver>] <initrd>');
   return shell.exit(1);
@@ -45,6 +45,14 @@ var initrdFile = String(argv._[0] || '');
 var qemuNet = 'user';
 if (typeof argv.net === 'string') {
   qemuNet = argv.net;
+}
+
+var extraPorts = [];
+if (typeof argv.port === 'number') {
+  extraPorts = [argv.port];
+}
+if (argv.port instanceof Array) {
+  extraPorts = argv.port;
 }
 
 var defaultKernelVersion = require('../package.json').runtimejsKernelVersion;
@@ -78,6 +86,7 @@ getRuntime(kernelVer, kernelFile, function(err, runtimeFile) {
     dryRun: dryRun,
     verbose: verbose,
     virtioRng: qemuVirtioRng,
-    nographic: qemuNographic
+    nographic: qemuNographic,
+    ports: extraPorts
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtime-tools",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "runtime.js tools",
   "main": "index.js",
   "scripts": {

--- a/qemu.js
+++ b/qemu.js
@@ -51,7 +51,11 @@ function getQemuArgs(opts) {
       a.push('-net bridge');
       break;
     case 'user':
-      a.push('-net user,net=192.168.76.0/24,dhcpstart=192.168.76.9,hostfwd=udp::9000-:9000,hostfwd=tcp::9000-:9000');
+      var pushString = '-net user,net=192.168.76.0/24,dhcpstart=192.168.76.9,hostfwd=udp::9000-:9000,hostfwd=tcp::9000-:9000';
+      for (var i = 0; i < opts.ports.length; i++) {
+        pushString += ',hostfwd=udp::' + opts.ports[i] + '-:'+ opts.ports[i] + ',hostfwd=tcp::' + opts.ports[i] + '-:' + opts.ports[i];
+      }
+      a.push(pushString);
       break;
     default:
       shell.echo(chalk.red('error: unknown network type (supported tap/bridge/user)'));


### PR DESCRIPTION
This PR adds a `--port` option (that can be specified multiple times). There's probably a better way to add the specified ports to QEMU's parameters, though.
